### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,7 @@
 modbus-tcpmaster/
 ├── .github/
 │   └── copilot-instructions.md   # This file
+├── .gitignore
 ├── MP2300SController.h           # Public API: MP2300SController ref class declaration
 ├── MP2300SController.cpp         # Modbus TCP protocol implementation
 ├── Main.cpp                      # Interactive console test harness
@@ -19,11 +20,12 @@ modbus-tcpmaster/
 ├── resource.h                    # Resource definitions
 ├── app.rc                        # Application resource script
 ├── app.ico                       # Application icon
-├── app.aps                       # Visual Studio resource editor cache (not committed)
+├── app.aps                       # Visual Studio resource editor cache
 ├── ModbusTCPMaster.sln           # Visual Studio solution file
 ├── ModbusTCPMaster.vcxproj       # Visual Studio project file (C++/CLI DLL)
 ├── ModbusTCPMaster.vcxproj.filters  # Source file filters for Solution Explorer
-├── ModbusTCPMaster.vcxproj.user     # Per-user project settings (not committed)
+├── ModbusTCPMaster.vcxproj.user     # Per-user project settings
+├── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── LICENSE
 └── README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
+- refreshed `.github/copilot-instructions.md` to add `CHANGELOG.md` and `.gitignore` to the repository structure and correct tracked-file annotations
+
 ### Removed
 
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.