### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,9 @@
 ```
 modbus-tcpmaster/
 ├── .github/
-│   └── copilot-instructions.md   # This file
+│   ├── copilot-instructions.md   # This file
+│   └── workflows/
+│       └── release.yaml          # Automated release pipeline (reusable workflow)
 ├── .gitignore
 ├── MP2300SController.h           # Public API: MP2300SController ref class declaration
 ├── MP2300SController.cpp         # Modbus TCP protocol implementation
@@ -64,9 +66,11 @@ modbus-tcpmaster/
 | Slave address | 1 | Hard-coded unit identifier |
 | Function code | 16 (0x10) | Write Multiple Registers |
 
-## Build Commands
+## CI / Release
 
-There is no automated CI pipeline. Builds are performed locally with Visual Studio or MSBuild on Windows.
+A `release.yaml` workflow runs on every push to `main` and delegates to a reusable pipeline in `rios0rios0/pipelines`. There is no build or test CI — builds are performed locally with Visual Studio or MSBuild on Windows.
+
+## Build Commands
 
 ### Visual Studio (recommended)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to add `release.yaml` to the repository structure and document the CI/release pipeline
+
 ## [0.1.1] - 2026-04-28
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.