### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `CLAUDE.md` with build commands, type-alias conventions, and architecture guidance for Claude Code sessions
+
 ## [0.1.2] - 2026-05-19
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+C++/CLI DLL implementing Modbus TCP (function code 16 — Write Multiple Registers) for Yaskawa MP2300S motion controllers. Two source files: `MP2300SController.h/.cpp` (library) and `Main.cpp` (interactive console test harness).
+
+## Build
+
+Windows-only. Requires Visual Studio 2017+ with the **C++/CLI support** component, **Desktop development with C++**, and **.NET desktop development** workloads. .NET Framework 4.0+.
+
+```bash
+msbuild ModbusTCPMaster.sln /p:Configuration=Debug /p:Platform=Win32
+msbuild ModbusTCPMaster.sln /p:Configuration=Release /p:Platform=x64
+```
+
+No automated test suite. Manual testing against a Modbus TCP simulator on port 502.
+
+## Conventions
+
+- Use the type aliases (`BYTE`, `WORD`, `INT`, `DINT`) defined in `MP2300SController.h` — not raw C++ types.
+- Managed allocations use `gcnew`; do not mix with native `new` for managed types.
+- Protocol and frame logic stays in `MP2300SController.cpp`; `Main.cpp` is only the test harness.
+- Error conditions throw `System::Exception` subclasses with messages including the Modbus error code in both decimal and hex.
+- Conventional commits with `feat/`, `fix/`, `chore/` branch prefixes. See the [Development Guide](https://github.com/rios0rios0/guide/wiki).


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.